### PR TITLE
Render round page with hard-coded user balance

### DIFF
--- a/src/Components/quiz/play/Quiz.jsx
+++ b/src/Components/quiz/play/Quiz.jsx
@@ -148,7 +148,8 @@ class Quiz extends Component {
                 changeArray.push((currentRow[SELL] * -1));
             }
             else {
-                throw "An error occurred when parsing the form input.";
+                alert("Please enter an action for each symbol");
+                break;
             }
         }
  

--- a/src/Components/quiz/play/Quiz.jsx
+++ b/src/Components/quiz/play/Quiz.jsx
@@ -1,29 +1,190 @@
 import React, { Component } from 'react';
-import {fire} from '../../../firebase.js';
-
-
+ 
+/*
+inherited from Play:
+  - chart URLs
+  - roomID
+  - symbols array
+  - prices array
+ 
+what Quiz does:
+  - retrieves and displays user information
+  - gets graph URLs from parent and displays
+  - HTML form to gather all input data
+  - submitHandlers for: 
+    - buy (+ # of shares)
+    - sell (+ # of shares)
+  - create changeArray to record investment in firestore
+*/
+ 
+// TODO: get this data from firestore
+const NUM_SYMBOLS = 3;
+const BALANCE = 1000;
+ 
+const BUY = "BUY";
+const SELL = "SELL";
+const HOLD = "HOLD";
+ 
 class Quiz extends Component {
-
+ 
+    // TODO: render charts on page
     constructor(props) {
         super(props);
-        this.state = {};
-        this.saveAnswer = this.saveAnswer.bind(this);
+        this.state = {
+          userBalance: BALANCE,  // call getUserCash
+          formInput: []
+        };
     }
-
-    saveAnswer(answer) {
-        let that = this;
-        let currentQuestionId = this.props.game.quiz.questions[this.props.game.quiz.currentQuestion].id;
-        fire.database().ref('/Rooms/' + that.props.game.key + '/players/' + this.props.playerKey + '/answers/' + currentQuestionId).set(answer, function(error) {
-            var x = 1+1;
+ 
+    // TODO: use firestore methods
+    getPrice = (symbolIndex) => {return 10;}
+    getShares = (symbolIndex) => {return 1;}
+    getBalance = () => {return BALANCE;}
+ 
+    getAvailableSymbols = () => {
+        let content = [];
+        for (let i = 0; i < NUM_SYMBOLS; i++) {
+            content.push(<li key={i}>Symbol{i}</li>);
         }
-        );
+        return content;
     }
-
+ 
+    addRowToFormData = () => {
+        const dataJSON = {
+            BUY: null,
+            HOLD: null,
+            SELL: null
+        };
+        this.state.formInput.push(dataJSON);
+    }
+ 
+    getSymbolData = () => {
+        let rows = [];
+ 
+        // get current price and user shares held for each of the symbols
+        // also present the BUY/HOLD/SELL options
+        for (let i = 0; i < NUM_SYMBOLS; i++) {
+            const currentPrice = this.getPrice(i);
+            const numShares = this.getShares(i);
+ 
+            const toRender = (
+                <div key={i}>
+                    <p>Symbol{i}:</p>
+                    <p>Current price is: {currentPrice}.</p>
+                    <p>You currently hold {numShares} share(s).</p>
+ 
+                    <button type="button">BUY</button>
+                    <input type="number" placeholder="10" onChange={(event) => this.updateFormState(event, i, BUY)}/>
+ 
+                    <button type="button" onClick={(event) => this.updateFormState(event, i, HOLD)}>HOLD</button>
+ 
+                    <button type="button">SELL</button>
+                    <input type="number" placeholder="10" onChange={(event) => this.updateFormState(event, i, SELL)}/>
+                    <br/>
+                </div>
+            );
+            rows.push(toRender);
+            this.addRowToFormData();
+        }
+ 
+        return rows;
+    }
+ 
+    // update state variable to reflect number of shares
+    updateFormState = (event, index, state) => {
+        var newState = {
+            BUY: null,
+            HOLD: null,
+            SELL: null
+        };
+ 
+        // handle different states
+        if (state === BUY) {
+            var numShares = event.target.value;
+ 
+            // value is deleted
+            if (!numShares) {
+                this.state.formInput[index][BUY] = null;
+                return;
+            }
+ 
+            newState[BUY] = Number(numShares);
+        }
+        else if (state === HOLD) {
+            newState[HOLD] = 1;  // indicate that user wants to Hold this investment with boolean flag
+        }
+        else if (state === SELL) {
+            var numShares = event.target.value;
+ 
+            // deletion
+            if (!numShares) {
+                this.state.formInput[index][SELL] = null;
+                return;
+            }
+ 
+            newState[SELL] = Number(numShares);
+        }
+        else {
+            throw "An unexpected error occurred when trying to process the state";
+        }
+ 
+        this.state.formInput[index] = newState;
+    }
+ 
+    // parse form submission results and convert into a changeArray (for firestore)
+    parseResults = () => {
+        var changeArray = [];
+ 
+        for (let i = 0; i < this.state.formInput.length; i++) {
+            const currentRow = this.state.formInput[i];
+ 
+            if (currentRow[BUY]) {
+                changeArray.push(currentRow[BUY]);
+            }
+            else if (currentRow[HOLD]) {
+                changeArray.push(0);  // invest 0 in symbol
+            }
+            else if (currentRow[SELL]) {
+                changeArray.push((currentRow[SELL] * -1));
+            }
+            else {
+                throw "An error occurred when parsing the form input.";
+            }
+        }
+ 
+        // TODO: call makeInvestment (firestore access) with changeArray
+    }
+ 
+    validate = (event) => {
+        // TODO: call verifyOK (firestore access method) to verify
+        // user input onChange
+    }
+ 
+ 
+    submitHandler = (event) => {
+        event.preventDefault();  // prevent page refresh
+        this.parseResults();
+    }
+ 
     render() {
+ 
         return (
-            <div></div>
+            <div>
+ 
+                <p>Available symbols are:</p>
+                <ul>{this.getAvailableSymbols()}</ul>
+                <p>Current Balance is {this.getBalance()}</p>
+                <br/>
+ 
+                <form onSubmit={this.submitHandler}>
+                    {this.getSymbolData()}
+                    <br/><br/>
+                    <input type="submit"/>
+                </form>
+            
+            </div>
         );
     }
 };
-
-export {Quiz};
+ 
+export default Quiz;


### PR DESCRIPTION
Creates a page for one round of the game. Contains:
- form for user to BUY/HOLD/SELL for each symbol in the game (number of symbols is hard-coded for now)
- validation to ensure that user selects only one option per input
- parses form submission to create shares array (changeArray) to be processed by the firestore method makeInvestment

page screenshot: https://screenshot.googleplex.com/AxudA7pAiBG

TODOs: in next commit, need to:
- integrate with the firestore access methods to retrieve user balance, room symbols
- download chart URLs and display on page
- call makeInvestment when form is submitted